### PR TITLE
fix(navbar): label and style

### DIFF
--- a/frontend/src/app/urgi-common/basket/basket/basket.component.html
+++ b/frontend/src/app/urgi-common/basket/basket/basket.component.html
@@ -3,7 +3,7 @@
   <span class="badge rounded-pill bg-light text-black">0</span>
 </div>
 <button
-  class="basket-counter btn"
+  class="basket-counter btn btn-link"
   *ngIf="isEnabled && itemCounter"
   [ngbTooltip]="buttonTooltip"
   (click)="viewItems(basketModal)"

--- a/frontend/src/environments/environment.rare.ts
+++ b/frontend/src/environments/environment.rare.ts
@@ -12,7 +12,7 @@ export const environment: DataDiscoveryEnvironment = {
   navbar: {
     logoUrl: '',
     secondLogoUrl: '',
-    links: [{ label: 'agrobrc-rare', url: 'https://www.agrobrc-rare.org/' }]
+    links: [{ label: 'agrobrc', url: 'https://www.agrobrc-rare.org/' }]
   },
   resourceModule: RareModule,
   helpMdFile: 'assets/help.md',


### PR DESCRIPTION
The label `agrobrc-rare` did not exist, so the key was displayed. Also improve the style of the basket button to avoid a weird border when the background of the navbar is dark.