### PR TITLE
fix(faidare): better type for templateRef in node component

### DIFF
--- a/frontend/src/app/faidare/tree/node/node.component.ts
+++ b/frontend/src/app/faidare/tree/node/node.component.ts
@@ -11,7 +11,7 @@ export class NodeComponent<P> {
   @Input() node!: InternalTreeNode<P>;
   @Input() filtered = false;
   @Input() highlightedNodeId: string | undefined;
-  @Input() payloadTemplate?: TemplateRef<HTMLElement>;
+  @Input() payloadTemplate?: TemplateRef<{ node: InternalTreeNode<P> }>;
 
   constructor(private treeService: TreeService<P>) {}
 

--- a/frontend/src/app/faidare/tree/tree.component.ts
+++ b/frontend/src/app/faidare/tree/tree.component.ts
@@ -71,7 +71,7 @@ export class TreeComponent<P> implements OnInit {
   private textAccessorSubject = new BehaviorSubject<TextAccessor<P>>(DEFAULT_TEXT_ACCESSOR);
 
   @Input()
-  payloadTemplate?: TemplateRef<HTMLElement>;
+  payloadTemplate?: TemplateRef<{ node: InternalTreeNode<P> }>;
 
   @Input()
   set rootNodes(rootNodes: Array<TreeNode<P>>) {


### PR DESCRIPTION
The current type fails when bumping to ng v16