### PR TITLE
fix(header): proper title for rare app

### DIFF
--- a/frontend/src/app/rare/rare-header/rare-header.component.spec.ts
+++ b/frontend/src/app/rare/rare-header/rare-header.component.spec.ts
@@ -5,13 +5,26 @@ import { RareHeaderComponent } from './rare-header.component';
 describe('RareHeaderComponent', () => {
   beforeEach(() => TestBed.configureTestingModule({}));
 
-  it('should display title and image', () => {
+  it('should display title and image for rare', () => {
     const fixture = TestBed.createComponent(RareHeaderComponent);
 
     fixture.detectChanges();
 
     const title = fixture.nativeElement.querySelector('h1');
     expect(title.textContent).toContain('RARe');
+
+    const image = fixture.nativeElement.querySelector('img');
+    expect(image).toBeDefined();
+  });
+
+  it('should display title and image for application other than rare', () => {
+    const fixture = TestBed.createComponent(RareHeaderComponent);
+    fixture.componentInstance.isRareApp = false;
+
+    fixture.detectChanges();
+
+    const title = fixture.nativeElement.querySelector('h1');
+    expect(title.textContent).toContain('BRC4EnvBiological');
 
     const image = fixture.nativeElement.querySelector('img');
     expect(image).toBeDefined();

--- a/frontend/src/app/rare/rare-header/rare-header.component.ts
+++ b/frontend/src/app/rare/rare-header/rare-header.component.ts
@@ -13,6 +13,6 @@ export class RareHeaderComponent {
   isRareApp: boolean;
 
   constructor() {
-    this.isRareApp = environment.title.startsWith('RARe');
+    this.isRareApp = environment.name === 'rare';
   }
 }

--- a/frontend/src/environments/environment.model.ts
+++ b/frontend/src/environments/environment.model.ts
@@ -20,7 +20,7 @@ export interface DataDiscoveryEnvironment {
   /**
    * Name of the app, used in the i18n process, to translate specific values
    */
-  name: string;
+  name: 'rare' | 'brc4env' | 'wheatis' | 'faidare';
   /**
    * The title of the application, displayed on screen
    */


### PR DESCRIPTION
The component was relying on the title of the aplication which was changed in https://forgemia.inra.fr/urgi-is/data-discovery/-/commit/7c8861f1aac3e9af7c17dbf444d64fede29e848f

It was now always displaying the brc4env title.