### PR TITLE
Fix/circular deps

### DIFF
--- a/frontend/src/app/aggregations/aggregations.component.ts
+++ b/frontend/src/app/aggregations/aggregations.component.ts
@@ -1,4 +1,11 @@
-import { ChangeDetectionStrategy, Component, output, input, model } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  forwardRef,
+  input,
+  model,
+  output
+} from '@angular/core';
 
 import { Aggregation } from '../models/page';
 import { AggregationCriterion } from '../models/aggregation-criterion';
@@ -17,7 +24,7 @@ import { environment } from '../../environments/environment';
     LoadingSkeletonComponent,
     SmallAggregationComponent,
     LargeAggregationComponent,
-    environment.ontologyAggregationComponent
+    forwardRef(() => environment.ontologyAggregationComponent)
   ]
 })
 export class AggregationsComponent {

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, inject } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 
 import { environment } from '../environments/environment';
@@ -13,7 +13,12 @@ import { toSignal } from '@angular/core/rxjs-interop';
   selector: 'dd-root',
   templateUrl: './app.component.html',
   styleUrl: './app.component.css',
-  imports: [NavbarComponent, ErrorComponent, RouterOutlet, environment.footerComponent],
+  imports: [
+    NavbarComponent,
+    ErrorComponent,
+    RouterOutlet,
+    forwardRef(() => environment.footerComponent)
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class AppComponent {

--- a/frontend/src/app/documents/documents.component.ts
+++ b/frontend/src/app/documents/documents.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, Signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, inject, Signal } from '@angular/core';
 import { BasketService } from '../urgi-common/basket/basket.service';
 import { map } from 'rxjs';
 import { DocumentModel } from '../models/document.model';
@@ -24,8 +24,8 @@ interface ViewModel {
   imports: [
     DecimalPipe,
     TranslateDirective,
-    environment.selectAllResultsComponent,
-    environment.documentListComponent
+    forwardRef(() => environment.selectAllResultsComponent),
+    forwardRef(() => environment.documentListComponent)
   ]
 })
 export class DocumentsComponent {

--- a/frontend/src/app/faidare/faidare-document-list/faidare-document-list.component.ts
+++ b/frontend/src/app/faidare/faidare-document-list/faidare-document-list.component.ts
@@ -3,6 +3,7 @@ import {
   Component,
   computed,
   effect,
+  forwardRef,
   inject,
   Signal
 } from '@angular/core';
@@ -82,7 +83,7 @@ export function toAllTransition(criteria: SearchCriteria): SearchCriteria {
     NgbNavOutlet,
     TranslateDirective,
     GermplasmResultsComponent,
-    environment.documentComponent
+    forwardRef(() => environment.documentComponent)
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/frontend/src/app/home/home.component.ts
+++ b/frontend/src/app/home/home.component.ts
@@ -1,4 +1,11 @@
-import { ChangeDetectionStrategy, Component, inject, signal, Signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  forwardRef,
+  inject,
+  signal,
+  Signal
+} from '@angular/core';
 import { NonNullableFormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { Params, Router, RouterLink } from '@angular/router';
 import { Observable } from 'rxjs';
@@ -25,7 +32,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
     NgbTypeahead,
     PillarsComponent,
     AggregationsComponent,
-    environment.headerComponent
+    forwardRef(() => environment.headerComponent)
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/frontend/src/app/navbar/navbar.component.ts
+++ b/frontend/src/app/navbar/navbar.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, signal } from '@angular/core';
 import { environment } from '../../environments/environment';
 import { RouterLink } from '@angular/router';
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core';
@@ -21,7 +21,7 @@ import {
     NgbDropdownToggle,
     NgbDropdownMenu,
     RouterLink,
-    environment.basketComponent
+    forwardRef(() => environment.basketComponent)
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })


### PR DESCRIPTION
It turns out one of the imports *already* had a forwardRef with a comment from you, @cexbrayat explaining it was needed to avoid circular dependencies. My guess is that when faidare was added, a new circular dependency appeared but at that time it was not a problem anymore, but it became a problem again because of the metadata in the bundles added by the new version of the CLI.